### PR TITLE
fix cursor position when browser is resized #9

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,6 +27,7 @@ function windowResize() {
 window.addEventListener("load", () => {
     windowResize();
 });
+window.onresize = windowResize;
 
 const startDraw = (e) => {
     isDrawing = true;


### PR DESCRIPTION
one line of code to fix the brush/cursor position when browser is resized.

Though it creates a new problem that, the canvas is erased when the `windowResize` function is called.